### PR TITLE
solution to catch changes by browser autofill

### DIFF
--- a/app/assets/javascripts/subdivision_select.js
+++ b/app/assets/javascripts/subdivision_select.js
@@ -21,15 +21,26 @@ var SubdivisionSelect = (function() {
     var self = this;
     self._enabledInputsBeforeSubmit();
 
-    $(this._countrySelect).change(function() {
+    self.country = this._countrySelect.val();
+    setInterval(poll, 500);
+    this._countrySelect.change(onChange);
+
+    function poll() {
+      if (self.country != self._countrySelect.val()) {
+        onChange();
+      }
+    }
+
+    function onChange() {
+      self.country = self._countrySelect.val();
       $.ajax( {
         url: "/subdivisions",
-        data: { country_code: $(this).val() }
-      }).success(function(newSubdivisions) {
+        data: { country_code: self.country }
+      }).done(function(newSubdivisions) {
         self._clearSubdivisionSelect();
         self._updateSubdivisionSelect(newSubdivisions);
       });
-    });
+    }
   };
 
   SubdivisionSelect.prototype._updateSubdivisionSelect = function(newSubdivisions) {


### PR DESCRIPTION
implement polling as a backup solution to catch changes by browser autofill (autofill does not dispatch change event)

depends on #4 (just the `this._countrySelect` variable needs to be jQuery object)