### PR TITLE
Fix $.ajax().success() for jQuery 3.0

### DIFF
--- a/app/assets/javascripts/subdivision_select.js
+++ b/app/assets/javascripts/subdivision_select.js
@@ -25,7 +25,7 @@ var SubdivisionSelect = (function() {
       $.ajax( {
         url: "/subdivisions",
         data: { country_code: $(this).val() }
-      }).success(function(newSubdivisions) {
+      }).done(function(newSubdivisions) {
         self._clearSubdivisionSelect();
         self._updateSubdivisionSelect(newSubdivisions);
       });


### PR DESCRIPTION
Fix $.ajax().success() to $.ajax().done() for jQuery 3.0

Deprecation notice below is available at https://api.jquery.com/jquery.ajax/

Deprecation Notice: The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callbacks are removed as of jQuery 3.0. You can use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.