### PR TITLE
Fix broken value method call for Rails 5.2 regarding ActionView Tags

### DIFF
--- a/lib/subdivision_select/tag_helper.rb
+++ b/lib/subdivision_select/tag_helper.rb
@@ -2,8 +2,19 @@ module SubdivisionSelect
   #class CountryNotFoundError < StandardError;end
   module TagHelper
     def subdivision_option_tags
+      # In Rails 5.2+, `value` accepts no arguments and must also be called
+      # called with parens to avoid the local variable of the same name
+      # https://github.com/rails/rails/pull/29791
+      selected_option = @options.fetch(:selected) do
+        if self.method(:value).arity == 0
+          value
+        else
+          value(@object)
+        end
+      end
+
       option_tags_options = {
-        selected: @options.fetch(:selected) { value(@object) },
+        selected: selected_option,
         disabled: @options[:disabled]
       }
 


### PR DESCRIPTION
hi guys,
this PR fixes an issue for Rails 5.2 regarding ActionView::Tags::Base

the following code: 
https://github.com/cllns/subdivision_select/blob/5323418d3a66cac32d5c780ebd525dc84b497623/lib/subdivision_select/tag_helper.rb#L5-L8

fails as value isn't called with any arguments from rails tag methods, eg:

https://github.com/rails/rails/blob/659c516bef2781cc66865fc78ed5dce682566d26/actionview/lib/action_view/helpers/tags/base.rb#L53

object is available here, so shouldn't need to be passed as an arg:

https://github.com/rails/rails/blob/659c516bef2781cc66865fc78ed5dce682566d26/actionview/lib/action_view/helpers/tags/base.rb#L10